### PR TITLE
Automate release for v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8047,7 +8047,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-node"
-version = "0.0.41-desss"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "clap",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quantus-node"
 description = "Quantus Node - Echo Chamber"
-version = "0.0.41-desss"
+version = "0.1.0"
 license = "Apache-2.0"
 authors.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
Automated version bump for release v0.1.0.

This is a stable release

Triggered by workflow run: https://github.com/Quantus-Network/chain-ru-test/actions/runs/15724176157

Type: minor