### PR TITLE
[PRE-RELEASE] Automate release for v0.1.2-rc-test-bbb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8047,7 +8047,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-node"
-version = "0.1.1-rc.1-test-pre-123"
+version = "0.1.2-rc-test-bbb"
 dependencies = [
  "async-trait",
  "clap",
@@ -8104,7 +8104,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-runtime"
-version = "0.1.1-rc.1-test-pre-123"
+version = "0.1.2-rc-test-bbb"
 dependencies = [
  "dilithium-crypto",
  "env_logger 0.11.8",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quantus-node"
 description = "Quantus Node - Echo Chamber"
-version = "0.1.1-rc.1-test-pre-123"
+version = "0.1.2-rc-test-bbb"
 license = "Apache-2.0"
 authors.workspace = true
 homepage.workspace = true

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quantus-runtime"
 description = "Quantus Runtime - Proof of Vibes"
-version = "0.1.1-rc.1-test-pre-123"
+version = "0.1.2-rc-test-bbb"
 license = "Apache-2.0"
 authors.workspace = true
 homepage.workspace = true

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -86,7 +86,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 110,
+    spec_version: 111,
     impl_version: 1,
     apis: apis::RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Automated version bump for release v0.1.2-rc-test-bbb.

This is a pre-release version with identifier: rc

Triggered by workflow run: https://github.com/Quantus-Network/chain-ru-test/actions/runs/15725417074

Type: patch