### PR TITLE
Automate release for v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8104,7 +8104,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-node"
-version = "0.3.1-test-genesis"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "clap",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quantus-node"
 description = "Quantus Node - Echo Chamber"
-version = "0.3.1-test-genesis"
+version = "0.4.0"
 license = "Apache-2.0"
 authors.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
Automated version bump for release v0.4.0.

https://github.com/Quantus-Network/chain-ru-test/actions/runs/15993316760

Triggered by workflow run: minor

Type: 