### PR TITLE
Automate release for v0.4.2-shell-gh-fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8122,7 +8122,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-node"
-version = "0.1.1-zoidberg-kiss"
+version = "0.4.2-shell-gh-fix"
 dependencies = [
  "async-trait",
  "circuit-builder",
@@ -8183,7 +8183,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-runtime"
-version = "0.1.1-zoidberg-kiss"
+version = "0.4.2-shell-gh-fix"
 dependencies = [
  "dilithium-crypto",
  "env_logger 0.11.8",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quantus-node"
 description = "Quantus Node - Echo Chamber"
-version = "0.1.1-zoidberg-kiss"
+version = "0.4.2-shell-gh-fix"
 license = "Apache-2.0"
 authors.workspace = true
 homepage.workspace = true

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quantus-runtime"
 description = "Quantus Runtime - Proof of Vibes"
-version = "0.1.1-zoidberg-kiss"
+version = "0.4.2-shell-gh-fix"
 license = "Apache-2.0"
 authors.workspace = true
 homepage.workspace = true

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -86,7 +86,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 105,
+    spec_version: 106,
     impl_version: 1,
     apis: apis::RUNTIME_API_VERSIONS,
     transaction_version: 2,


### PR DESCRIPTION
Automated version bump for release v0.4.2-shell-gh-fix.

https://github.com/Quantus-Network/chain-ru-test/actions/runs/16744302188

Triggered by workflow run: patch

Type: 